### PR TITLE
Feature/test data generator

### DIFF
--- a/ec2.tf
+++ b/ec2.tf
@@ -80,7 +80,7 @@ resource "aws_autoscaling_group" "ecs-autoscaling-group" {
   max_size             = "${var.asg_max_instance_count}"
   min_size             = "${var.asg_min_instance_count}"
   desired_capacity     = "${var.asg_desired_instance_count}"
-  vpc_zone_identifier  = split(",", var.application_subnet_ids)
+  vpc_zone_identifier  = split(",", var.subnet_ids)
   launch_configuration = "${aws_launch_configuration.ecs-launch-configuration.name}"
   health_check_type    = "ELB"
 

--- a/ec2.tf
+++ b/ec2.tf
@@ -10,7 +10,7 @@ resource "aws_security_group" "ec2-security-group" {
     to_port     = 80
     protocol    = "tcp"
     cidr_blocks = split(",", var.ec2_ingress_cidr_blocks)
-    security_groups = [var.ec2_ingress_sg_id]
+    security_groups = var.ec2_ingress_sg_id
   }
 
   // HTTPS

--- a/test/main.tf
+++ b/test/main.tf
@@ -41,8 +41,8 @@ module "ecs-cluster" {
   environment = local.environment
 
   # Network Variables
-  vpc_id                 = "${data.aws_vpc.default.id}"
-  application_subnet_ids = "${join(",", data.aws_subnet_ids.all.ids)}"
+  vpc_id     = "${data.aws_vpc.default.id}"
+  subnet_ids = "${join(",", data.aws_subnet_ids.all.ids)}"
 
   # Auto Scaling Group Variables
   asg_max_instance_count     = local.asg_max_instance_count

--- a/variables.tf
+++ b/variables.tf
@@ -21,8 +21,8 @@ variable "vpc_id" {
   description = "ID of the VPC to deploy resources into."
   type        = "string"
 }
-variable "application_subnet_ids" {
-  description = "Comma seperated list of subnet ids to deploy the cluster into. Effectively the subnets to run applications in."
+variable "subnet_ids" {
+  description = "Comma seperated list of subnet ids to deploy the cluster into."
   type        = "string"
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -72,6 +72,6 @@ variable "ec2_ingress_cidr_blocks" {
 }
 variable "ec2_ingress_sg_id" {
   description = "The security groups from which to allow access to port 80."
-  type        = "string"
-  default     = ""
+  type        = list(string)
+  default     = []
 }


### PR DESCRIPTION
Updates the library to rename the variable `application_subnet_ids` to `subnet_ids`. This was picked up in a PR for the Test Data Generator [here](https://github.com/companieshouse/test-data-generator-stack/pull/2#discussion_r390842233).

This branch also resolves a bug discovered during testing where the an ingress rule security group was getting change from:
`- security_groups  = []`
to:
`+ security_groups  = [   + "",  ]`
(something strange happening where the empty string was being converted to an empty list)

Resolves: DVOP-902