### PR TITLE
allow for AWS container insights (default is off)

### DIFF
--- a/ecs.tf
+++ b/ecs.tf
@@ -1,3 +1,7 @@
 resource "aws_ecs_cluster" "ecs-cluster" {
   name = "${var.name_prefix}-cluster"
+  setting {
+    name  = "containerInsights"
+    value = var.container_insights_enablement
+  }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -75,3 +75,12 @@ variable "ec2_ingress_sg_id" {
   type        = "string"
   default     = ""
 }
+
+//----------------------------------------------------------------------
+// Networking Variables
+//----------------------------------------------------------------------
+variable "container_insights_enablement" {
+  description = "Whether contain sights are set  Value values are [enabled',disabled]"
+  type        = "string"
+  default     = "disabled"
+}


### PR DESCRIPTION
Add extra option when creating a AWS instance to add container insights (default is disabled)
