### PR TITLE
add container insights option

### DIFF
--- a/ecs.tf
+++ b/ecs.tf
@@ -1,3 +1,7 @@
 resource "aws_ecs_cluster" "ecs-cluster" {
   name = "${var.name_prefix}-cluster"
+  setting {
+    name  = "containerInsights"
+    value = var.container_insights_enablement
+  }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -80,7 +80,7 @@ variable "ec2_ingress_sg_id" {
 // Networking Variables
 //----------------------------------------------------------------------
 variable "container_insights_enablement" {
-  description = "Whether contain sights are set  Value values are [enabled',disabled]"
+  description = "Whether container sights are set, valid values are [enabled,disabled]"
   type        = "string"
   default     = "disabled"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -77,7 +77,7 @@ variable "ec2_ingress_sg_id" {
 }
 
 //----------------------------------------------------------------------
-// Networking Variables
+// ECS Cluster Variables
 //----------------------------------------------------------------------
 variable "container_insights_enablement" {
   description = "Whether container sights are set, valid values are [enabled,disabled]"

--- a/variables.tf
+++ b/variables.tf
@@ -75,3 +75,12 @@ variable "ec2_ingress_sg_id" {
   type        = "string"
   default     = ""
 }
+
+//----------------------------------------------------------------------
+// Networking Variables
+//----------------------------------------------------------------------
+variable "container_insights_enablement" {
+  description = "Whether contain sights are set  Value values are [enabled',disabled]"
+  type        = "string"
+  default     = "disabled"
+}


### PR DESCRIPTION
IVP-1355

Add Container insights option (default is disabled) when creating a new ECS cluster

When testing locally (with project with container_insights_enablement= enabled as default ) and then I run `export TF_VAR_container_insights_enablement=disabled` then the terraform plan does not mention container insights (but it does if I do not use this variable - then it wants it enabled due to the project settings)