### PR TITLE
Update syntax to avoid deprecation warnings from terraform

### DIFF
--- a/ec2.tf
+++ b/ec2.tf
@@ -2,7 +2,7 @@
 resource "aws_security_group" "ec2-security-group" {
   name        = "${var.name_prefix}-ec2-sg"
   description = "Allow HTTP, HTTPS, and SSH"
-  vpc_id      = "${var.vpc_id}"
+  vpc_id      = var.vpc_id
 
   // HTTP
   ingress {
@@ -56,12 +56,12 @@ resource "aws_security_group" "ec2-security-group" {
 // ---- Launch Configuration ----
 resource "aws_launch_configuration" "ecs-launch-configuration" {
   name_prefix                 = "${var.name_prefix}-"
-  image_id                    = "${var.ec2_image_id}"
-  instance_type               = "${var.ec2_instance_type}"
+  image_id                    = var.ec2_image_id
+  instance_type               = var.ec2_instance_type
   iam_instance_profile        = aws_iam_instance_profile.ecs-instance-profile.name
-  security_groups             = ["${aws_security_group.ec2-security-group.id}"]
+  security_groups             = [aws_security_group.ec2-security-group.id]
   associate_public_ip_address = false
-  key_name                    = "${var.ec2_key_pair_name}"
+  key_name                    = var.ec2_key_pair_name
   user_data = templatefile(
     "${path.module}/ec2-user-data.tmpl",
     {
@@ -77,11 +77,11 @@ resource "aws_launch_configuration" "ecs-launch-configuration" {
 //---- Auto Scaling Group ----
 resource "aws_autoscaling_group" "ecs-autoscaling-group" {
   name                 = "${var.name_prefix}-ecs-asg"
-  max_size             = "${var.asg_max_instance_count}"
-  min_size             = "${var.asg_min_instance_count}"
-  desired_capacity     = "${var.asg_desired_instance_count}"
+  max_size             = var.asg_max_instance_count
+  min_size             = var.asg_min_instance_count
+  desired_capacity     = var.asg_desired_instance_count
   vpc_zone_identifier  = split(",", var.subnet_ids)
-  launch_configuration = "${aws_launch_configuration.ecs-launch-configuration.name}"
+  launch_configuration = aws_launch_configuration.ecs-launch-configuration.name
   health_check_type    = "ELB"
 
   lifecycle {
@@ -96,7 +96,7 @@ resource "aws_autoscaling_group" "ecs-autoscaling-group" {
     },
     {
       key                 = "Environment"
-      value               = "${var.environment}"
+      value               = var.environment
       propagate_at_launch = true
     }
   ]

--- a/iam.tf
+++ b/iam.tf
@@ -2,14 +2,14 @@
 resource "aws_iam_instance_profile" "ecs-instance-profile" {
   name = "${var.name_prefix}-ecs-instance-profile"
   path = "/"
-  role = "${aws_iam_role.ecs-instance-role.name}"
+  role = aws_iam_role.ecs-instance-role.name
 }
 
 // ---- ECS Instance Role ----
 resource "aws_iam_role" "ecs-instance-role" {
   name               = "${var.name_prefix}-ecs-instance-role"
   path               = "/"
-  assume_role_policy = "${data.aws_iam_policy_document.ecs-instance-policy.json}"
+  assume_role_policy = data.aws_iam_policy_document.ecs-instance-policy.json
 }
 
 data "aws_iam_policy_document" "ecs-instance-policy" {
@@ -25,7 +25,7 @@ data "aws_iam_policy_document" "ecs-instance-policy" {
 
 resource "aws_iam_role_policy" "cloudwatch-logs-policy" {
   name = "cloudwatch-logs-policy"
-  role = "${aws_iam_role.ecs-instance-role.id}"
+  role = aws_iam_role.ecs-instance-role.id
 
   policy = <<EOF
 {
@@ -43,7 +43,7 @@ EOF
 
 resource "aws_iam_role_policy" "iam-pass-role-policy" {
   name = "iam-pass-role-policy"
-  role = "${aws_iam_role.ecs-instance-role.id}"
+  role = aws_iam_role.ecs-instance-role.id
 
   policy = <<EOF
 {
@@ -63,7 +63,7 @@ EOF
 }
 
 resource "aws_iam_role_policy_attachment" "ecs-instance-role-attachment" {
-  role       = "${aws_iam_role.ecs-instance-role.name}"
+  role       = aws_iam_role.ecs-instance-role.name
   policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonEC2ContainerServiceforEC2Role"
 }
 
@@ -72,11 +72,11 @@ resource "aws_iam_role_policy_attachment" "ecs-instance-role-attachment" {
 resource "aws_iam_role" "ecs-service-role" {
   name               = "${var.name_prefix}-ecs-service-role"
   path               = "/"
-  assume_role_policy = "${data.aws_iam_policy_document.ecs-service-policy.json}"
+  assume_role_policy = data.aws_iam_policy_document.ecs-service-policy.json
 }
 
 resource "aws_iam_role_policy_attachment" "ecs-service-role-attachment" {
-  role       = "${aws_iam_role.ecs-service-role.name}"
+  role       = aws_iam_role.ecs-service-role.name
   policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonEC2ContainerServiceRole"
 }
 
@@ -96,7 +96,7 @@ data "aws_iam_policy_document" "ecs-service-policy" {
 
 resource "aws_iam_role_policy" "ecs-secrets-policy" {
   name = "ecs-secrets-policy"
-  role = "${aws_iam_role.ecs-service-role.id}"
+  role = aws_iam_role.ecs-service-role.id
 
   policy = <<EOF
 {
@@ -125,11 +125,11 @@ EOF
 resource "aws_iam_role" "ecs-task-execution-role" {
   name               = "${var.name_prefix}-ecs-task-execution-role"
   path               = "/"
-  assume_role_policy = "${data.aws_iam_policy_document.ecs-task-execution-policy.json}"
+  assume_role_policy = data.aws_iam_policy_document.ecs-task-execution-policy.json
 }
 
 resource "aws_iam_role_policy_attachment" "ecs-task-execution-role-attachment" {
-  role       = "${aws_iam_role.ecs-task-execution-role.name}"
+  role       = aws_iam_role.ecs-task-execution-role.name
   policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonEC2ContainerServiceRole"
 }
 
@@ -149,7 +149,7 @@ data "aws_iam_policy_document" "ecs-task-execution-policy" {
 
 resource "aws_iam_role_policy" "ecs-task-execution-policy" {
   name = "ecs-task-execution-policy"
-  role = "${aws_iam_role.ecs-task-execution-role.id}"
+  role = aws_iam_role.ecs-task-execution-role.id
 
   policy = <<EOF
 {

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,34 +1,34 @@
 // ECS module outputs
 output "ecs_cluster_id" {
-  value = "${aws_ecs_cluster.ecs-cluster.id}"
+  value = aws_ecs_cluster.ecs-cluster.id
 }
 
 output "ecs_cluster_name" {
-  value = "${aws_ecs_cluster.ecs-cluster.name}"
+  value = aws_ecs_cluster.ecs-cluster.name
 }
 
 output "ecs_cluster_sg_id" {
-  value = "${aws_security_group.ec2-security-group.id}"
+  value = aws_security_group.ec2-security-group.id
 }
 
 output "ecs_cluster_autoscalinggroup_arn" {
-  value = "${aws_autoscaling_group.ecs-autoscaling-group.arn}"
+  value = aws_autoscaling_group.ecs-autoscaling-group.arn
 }
 
 // IAM module outputs
 
 output "ecs_instance_profile_name" {
-  value = "${aws_iam_instance_profile.ecs-instance-profile.name}"
+  value = aws_iam_instance_profile.ecs-instance-profile.name
 }
 
 output "ecs_instance_role_name" {
-  value = "${aws_iam_role.ecs-instance-role.name}"
+  value = aws_iam_role.ecs-instance-role.name
 }
 
 output "ecs_service_role_arn" {
-  value = "${aws_iam_role.ecs-service-role.arn}"
+  value = aws_iam_role.ecs-service-role.arn
 }
 
 output "ecs_task_execution_role_arn" {
-  value = "${aws_iam_role.ecs-task-execution-role.arn}"
+  value = aws_iam_role.ecs-task-execution-role.arn
 }

--- a/variables.tf
+++ b/variables.tf
@@ -3,15 +3,15 @@
 //----------------------------------------------------------------------
 variable "stack_name" {
   description = "The name of the infrastructure 'stack' this cluster is part of."
-  type        = "string"
+  type        = string
 }
 variable "environment" {
   description = "The name of the environment this cluster is part of e.g. live, staging, dev. etc."
-  type        = "string"
+  type        = string
 }
 variable "name_prefix" {
   description = "The prefix to use when naming resources in this cluster. Usually a combination of environment and stack_name for concistency e.g. '{stack_name}-{environment}'."
-  type        = "string"
+  type        = string
 }
 
 //----------------------------------------------------------------------
@@ -19,11 +19,11 @@ variable "name_prefix" {
 //----------------------------------------------------------------------
 variable "vpc_id" {
   description = "ID of the VPC to deploy resources into."
-  type        = "string"
+  type        = string
 }
 variable "subnet_ids" {
   description = "Comma seperated list of subnet ids to deploy the cluster into."
-  type        = "string"
+  type        = string
 }
 
 //----------------------------------------------------------------------
@@ -52,22 +52,22 @@ variable "asg_desired_instance_count" {
 //----------------------------------------------------------------------
 variable "ec2_key_pair_name" {
   description = "The ec2 key pair name for SSH access to ec2 instances in the clusters auto scaling group."
-  type        = "string"
+  type        = string
   default     = "" # Empty string implies no key pair should be used so no SSH access is available on the instances
 }
 variable "ec2_image_id" {
   description = "The name for the autoscaling group for the cluster."
-  type        = "string"
+  type        = string
   default     = "ami-0f49b2a9014635082" # ECS optimized Amazon Linux in London created 10/07/2019
 }
 variable "ec2_instance_type" {
   description = "The ec2 instance type for ec2 instances in the clusters auto scaling group."
-  type        = "string"
+  type        = string
   default     = "t3.micro"
 }
 variable "ec2_ingress_cidr_blocks" {
   description = "Comma seperated list of ingress CIDR ranges to allow access to application ports."
-  type        = "string"
+  type        = string
   default     = "0.0.0.0/0"
 }
 variable "ec2_ingress_sg_id" {
@@ -81,6 +81,6 @@ variable "ec2_ingress_sg_id" {
 //----------------------------------------------------------------------
 variable "container_insights_enablement" {
   description = "Whether container sights are set, valid values are [enabled,disabled]"
-  type        = "string"
+  type        = string
   default     = "disabled"
 }


### PR DESCRIPTION

When working on CM-1010, enabling access to the api from the heritage accounts, I've found there are lots of deprecation warnings when running the terraform due to the old syntax used, so I have updated it to remove the warnings.
