### PR TITLE
Setting default ecs AMI to latest amazon2 ecs optimized image

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -58,7 +58,7 @@ variable "ec2_key_pair_name" {
 variable "ec2_image_id" {
   description = "The name for the autoscaling group for the cluster."
   type        = string
-  default     = "ami-0f49b2a9014635082" # ECS optimized Amazon Linux in London created 10/07/2019
+  default     = "ami-04018f95156d810bc" # ECS optimized Amazon2 Linux in London created 15/03/2023
 }
 variable "ec2_instance_type" {
   description = "The ec2 instance type for ec2 instances in the clusters auto scaling group."


### PR DESCRIPTION
As part of the AMI upgrade for ECS migration, this is the selected AMI based on the investigation to use EC2 service type on ECS clusters. https://companieshouse.atlassian.net/wiki/spaces/COM/pages/4119134240/AMI+Upgrade. This has been added as a default for now and will set as a data lookup in the future