### PR TITLE
Encapsulate AWS provider config from dependent projects

### DIFF
--- a/ecs.tf
+++ b/ecs.tf
@@ -2,6 +2,6 @@ resource "aws_ecs_cluster" "ecs-cluster" {
   name = "${var.name_prefix}-cluster"
   setting {
     name  = "containerInsights"
-    value = var.container_insights_enablement
+    value = var.enable_container_insights ? "enabled" : "disabled"
   }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -79,8 +79,8 @@ variable "ec2_ingress_sg_id" {
 //----------------------------------------------------------------------
 // ECS Cluster Variables
 //----------------------------------------------------------------------
-variable "container_insights_enablement" {
-  description = "Whether container sights are set, valid values are [enabled,disabled]"
-  type        = string
-  default     = "disabled"
+variable "enable_container_insights" {
+  description = "A boolean value indicating whether to enable Container Insights or not"
+  type        = bool
+  default     = false
 }


### PR DESCRIPTION
These changes encapsulate AWS provider resource details from dependent projects, specifically for enabling Container Insights, to avoid the need for external changes should the values change in future provider updates. 