### PR TITLE
Add optional ASG schedules for scale down and up

### DIFF
--- a/ec2.tf
+++ b/ec2.tf
@@ -111,6 +111,7 @@ resource "aws_autoscaling_schedule" "schedule-scaledown" {
   max_size               = 0
   desired_capacity       = 0
   recurrence             = var.scaledown_schedule
+  time_zone              = "Europe/London"
   autoscaling_group_name = aws_autoscaling_group.ecs-autoscaling-group.name
 }
 
@@ -123,5 +124,6 @@ resource "aws_autoscaling_schedule" "schedule-scaleup" {
   max_size               = var.asg_max_instance_count
   desired_capacity       = var.asg_desired_instance_count
   recurrence             = var.scaleup_schedule
+  time_zone              = "Europe/London"
   autoscaling_group_name = aws_autoscaling_group.ecs-autoscaling-group.name
 }

--- a/ec2.tf
+++ b/ec2.tf
@@ -101,3 +101,27 @@ resource "aws_autoscaling_group" "ecs-autoscaling-group" {
     }
   ]
 }
+
+# ASG scheduled shutdown
+resource "aws_autoscaling_schedule" "schedule-scaledown" {
+  count = length(var.scaledown_schedule) > 0 ? 1 : 0
+
+  scheduled_action_name  = "${var.name_prefix}-scheduled-scaledown"
+  min_size               = 0
+  max_size               = 0
+  desired_capacity       = 0
+  recurrence             = var.scaledown_schedule
+  autoscaling_group_name = aws_autoscaling_group.ecs-autoscaling-group.name
+}
+
+# ASG scheduled startup
+resource "aws_autoscaling_schedule" "schedule-scaleup" {
+  count = length(var.scaleup_schedule) > 0 ? 1 : 0
+  
+  scheduled_action_name  = "${var.name_prefix}-scheduled-scaleup"
+  min_size               = var.asg_min_instance_count
+  max_size               = var.asg_max_instance_count
+  desired_capacity       = var.asg_desired_instance_count
+  recurrence             = var.scaleup_schedule
+  autoscaling_group_name = aws_autoscaling_group.ecs-autoscaling-group.name
+}

--- a/test/main.tf
+++ b/test/main.tf
@@ -8,6 +8,8 @@ locals {
   asg_max_instance_count     = 1
   asg_min_instance_count     = 1
   asg_desired_instance_count = 1
+  scaledown_schedule         = "00 20 * * 1-7"
+  scaleup_schedule           = "00 06 * * 1-7"
   ec2_instance_type          = "t3.micro"
   ec2_key_pair_name          = ""                      #"stack-pocs"
   ec2_image_id               = "ami-0f49b2a9014635082" # ECS optimized Amazon Linux in London created 10/07/2019
@@ -24,7 +26,7 @@ terraform {
   }
 }
 
-# Get default VPC and subnets to keep test simple rather than using netowkrs remote state
+# Get default VPC and subnets to keep test simple rather than using networks remote state
 data "aws_vpc" "default" {
   default = true
 }
@@ -48,6 +50,8 @@ module "ecs-cluster" {
   asg_max_instance_count     = local.asg_max_instance_count
   asg_min_instance_count     = local.asg_min_instance_count
   asg_desired_instance_count = local.asg_desired_instance_count
+  scaledown_schedule         = local.scaledown_schedule
+  scaleup_schedule           = local.scaleup_schedule
 
   # EC2 Launch Configuration Variables
   ec2_key_pair_name       = local.ec2_key_pair_name

--- a/variables.tf
+++ b/variables.tf
@@ -47,6 +47,24 @@ variable "asg_desired_instance_count" {
   default     = 2
 }
 
+variable "scaledown_schedule" {
+  description = "The schedule to use when scaling down the number of EC2 instances to zero."
+  # Typically used to stop all instances in a cluster to save resource costs overnight.
+  # E.g. a value of '00 20 * * 1-7' would be Mon-Sun 8pm.  An empty string indicates that no schedule should be created.
+
+  type        = string
+  default     = ""
+}
+
+variable "scaleup_schedule" {
+  description = "The schedule to use when scaling up the number of EC2 instances to their normal desired level."
+  # Typically used to start all instances in a cluster after it has been shutdown overnight.
+  # E.g. a value of '00 06 * * 1-7' would be Mon-Sun 6am.  An empty string indicates that no schedule should be created.
+
+  type        = string
+  default     = ""
+}
+
 //----------------------------------------------------------------------
 // EC2 Launch Configuration Variables
 //----------------------------------------------------------------------


### PR DESCRIPTION
Adds schedules to the ASG configuration to allow the EC2 instances to be scaled down to zero and up to the normal desired level at times provided by the input vars `scaledown_schedule` & `scaleup_schedule`

The default value for each of these vars is a blank string, which results in no change to current behaviour as no schedules will be created in that case.  If a value is supplied for either or both vars then the corresponding schedule will be created - e.g. 
`scaledown_schedule = "00 20 * * 1-7"` the EC2 instances will be scaled to zero at 8pm Mon-Sun.
`scaleup_schedule = "00 06 * * 1-7"` the EC2 instances will be scaled up to normal levels (already defined by asg_desired_instance_count/asg_max_instance_count/asg_min_instance_count) at 6am Mon-Sun.

Resolves:
https://companieshouse.atlassian.net/browse/CC-795