### PR TITLE
Add ASG auto-scaling capacity provider and config

### DIFF
--- a/ec2.tf
+++ b/ec2.tf
@@ -76,30 +76,37 @@ resource "aws_launch_configuration" "ecs-launch-configuration" {
 
 //---- Auto Scaling Group ----
 resource "aws_autoscaling_group" "ecs-autoscaling-group" {
-  name                 = "${var.name_prefix}-ecs-asg"
-  max_size             = var.asg_max_instance_count
-  min_size             = var.asg_min_instance_count
-  desired_capacity     = var.asg_desired_instance_count
-  vpc_zone_identifier  = split(",", var.subnet_ids)
-  launch_configuration = aws_launch_configuration.ecs-launch-configuration.name
-  health_check_type    = "ELB"
+  name                  = "${var.name_prefix}-ecs-asg"
+  max_size              = var.asg_max_instance_count
+  min_size              = var.asg_min_instance_count
+  desired_capacity      = var.asg_desired_instance_count
+  vpc_zone_identifier   = split(",", var.subnet_ids)
+  launch_configuration  = aws_launch_configuration.ecs-launch-configuration.name
+  health_check_type     = "ELB"
+  protect_from_scale_in = var.enable_asg_autoscaling
 
   lifecycle {
     create_before_destroy = true
   }
 
-  tags = [
-    {
-      key                 = "Name"
-      value               = "${var.name_prefix}-ecs-instance"
-      propagate_at_launch = true
-    },
-    {
-      key                 = "Environment"
-      value               = var.environment
+  tag {
+    key                 = "Name"
+    value               = "${var.name_prefix}-ecs-instance"
+    propagate_at_launch = true
+  }
+  tag  {
+    key                 = "Environment"
+    value               = var.environment
+    propagate_at_launch = true
+  }
+  dynamic "tag" {
+    for_each = var.enable_asg_autoscaling ? [""] : []
+    content {
+      key                 = "AmazonECSManaged"
+      value               = true
       propagate_at_launch = true
     }
-  ]
+  }
 }
 
 # ASG scheduled shutdown

--- a/ecs.tf
+++ b/ecs.tf
@@ -26,7 +26,7 @@ resource "aws_ecs_capacity_provider" "ec2_capacity_provider" {
 resource "aws_ecs_cluster_capacity_providers" "ecs_cluster_capacity_providers" {
   count              = var.enable_asg_autoscaling ? 1 : 0
   cluster_name       = aws_ecs_cluster.ecs-cluster.name
-  capacity_providers = [aws_ecs_capacity_provider.ec2_capacity_provider[0].name, "FARGATE"]
+  capacity_providers = [aws_ecs_capacity_provider.ec2_capacity_provider[0].name]
 
   # default to using EC2 if no capacity provider strategy is defined for a service
   default_capacity_provider_strategy {

--- a/ecs.tf
+++ b/ecs.tf
@@ -15,10 +15,10 @@ resource "aws_ecs_capacity_provider" "ec2_capacity_provider" {
     managed_termination_protection = "ENABLED"
 
     managed_scaling {
-      maximum_scaling_step_size = 150
-      minimum_scaling_step_size = 1
+      maximum_scaling_step_size = var.maximum_scaling_step_size
+      minimum_scaling_step_size = var.minimum_scaling_step_size
       status                    = "ENABLED"
-      target_capacity           = 100
+      target_capacity           = var.target_capacity
     }
   }
 }

--- a/ecs.tf
+++ b/ecs.tf
@@ -5,3 +5,32 @@ resource "aws_ecs_cluster" "ecs-cluster" {
     value = var.enable_container_insights ? "enabled" : "disabled"
   }
 }
+
+resource "aws_ecs_capacity_provider" "ec2_capacity_provider" {
+  count = var.enable_asg_autoscaling ? 1 : 0
+  name  = "capacity-provider-${var.name_prefix}"
+
+  auto_scaling_group_provider {
+    auto_scaling_group_arn         = aws_autoscaling_group.ecs-autoscaling-group.arn
+    managed_termination_protection = "ENABLED"
+
+    managed_scaling {
+      maximum_scaling_step_size = 150
+      minimum_scaling_step_size = 1
+      status                    = "ENABLED"
+      target_capacity           = 100
+    }
+  }
+}
+
+resource "aws_ecs_cluster_capacity_providers" "ecs_cluster_capacity_providers" {
+  count              = var.enable_asg_autoscaling ? 1 : 0
+  cluster_name       = aws_ecs_cluster.ecs-cluster.name
+  capacity_providers = [aws_ecs_capacity_provider.ec2_capacity_provider[0].name, "FARGATE"]
+
+  # default to using EC2 if no capacity provider strategy is defined for a service
+  default_capacity_provider_strategy {
+    weight            = 100
+    capacity_provider = aws_ecs_capacity_provider.ec2_capacity_provider[0].name
+  }
+}

--- a/variables.tf
+++ b/variables.tf
@@ -65,6 +65,12 @@ variable "scaleup_schedule" {
   default     = ""
 }
 
+variable "enable_asg_autoscaling" {
+  type        = bool
+  description = "Whether to enable auto-scaling of the ASG by creating a capacity provider for the ECS cluster."
+  default     = false
+}
+
 //----------------------------------------------------------------------
 // EC2 Launch Configuration Variables
 //----------------------------------------------------------------------

--- a/variables.tf
+++ b/variables.tf
@@ -66,9 +66,27 @@ variable "scaleup_schedule" {
 }
 
 variable "enable_asg_autoscaling" {
-  type        = bool
   description = "Whether to enable auto-scaling of the ASG by creating a capacity provider for the ECS cluster."
+  type        = bool
   default     = false
+}
+
+variable "maximum_scaling_step_size" {
+  description = "The maximum number of Amazon EC2 instances that Amazon ECS will scale out at one time.  Total is limited by asg_max_instance_count too."
+  type        = number
+  default     = 150
+}
+
+variable "minimum_scaling_step_size" {
+  description = "The minimum number of Amazon EC2 instances that Amazon ECS will scale out at one time."
+  type        = number
+  default     = 1
+}
+
+variable "target_capacity" {
+  description = "The target capacity utilization as a percentage for the capacity provider."
+  type        = number
+  default     = 100
 }
 
 //----------------------------------------------------------------------


### PR DESCRIPTION
Allows the ECS cluster to manage the scaling of Amazon EC2 instances that are registered to the cluster (i.e. within the ASG).

A new var `enable_asg_autoscaling` has been created.  If set to false (default) no infrastructure changes will be made.  
If set to true, then an aws_ecs_capacity_provider resource will be added and associated with the ASG and ECS cluster.  
Additionally, scale in protection will be enabled for the ASG and a new tag `AmazonECSManaged` is also added -  these are both required to use the managed scaling.

Partially resolves:
https://companieshouse.atlassian.net/browse/CC-292